### PR TITLE
Auto Enabling Without Settings

### DIFF
--- a/includes/override.php
+++ b/includes/override.php
@@ -21,3 +21,61 @@ function dekode_ninja_forms_uploads_external_service_azure( array $services ): a
 	$services[ DEKODE_NINJAFORMS_AZURE_DIR_PATH . '/includes/service/class-nf-fu-external-services-azure-service.php' ] = 'azure';
 	return $services;
 }
+
+/**
+ * Disables saving to uploads directory.
+ *
+ * @param array $fields List of fields.
+ * @param int   $form_id Form ID.
+ * @return array
+ */
+function dekode_ninja_forms_get_fields( array $fields, int $form_id ): array {
+	foreach ( $fields as $field ) {
+		if ( 'file_upload' === $field->get_setting( 'type' ) ) {
+
+			$field->update_setting( 'save_to_server', 0 );
+			$field->update_setting( 'media_library', 0 );
+		}
+	}
+
+	return $fields;
+}
+
+add_filter( 'ninja_forms_get_fields', __NAMESPACE__ . '\\dekode_ninja_forms_get_fields', 1, 2 );
+
+/**
+ * Adds virtual action for all upload fields.
+ *
+ * @param array $actions List of actions.
+ * @param array $form_cache Form configuration.
+ * @param array $form_data Form data.
+ * @return array
+ */
+function dekode_ninja_forms_submission_actions( array $actions, array $form_cache, array $form_data ):array {
+	$fields = $form_cache['fields'];
+
+	$settings = [
+		'title'              => null,
+		'key'                => null,
+		'type'               => 'file-upload-external',
+		'active'             => '1',
+		'fields-save-toggle' => 'save_all',
+		'drawerDisabled'     => '',
+	];
+
+	foreach ( $fields as $field ) {
+		if ( 'file_upload' === $field['settings']['type'] ) {
+			$settings[ 'field_list_azure-' . $field['settings']['key'] ] = 1;
+		}
+	}
+
+	$actions[] = [
+		'id'       => 1000000,
+		'settings' => $settings,
+	];
+
+	return $actions;
+}
+
+add_filter( 'ninja_forms_submission_actions', __NAMESPACE__ . '\\dekode_ninja_forms_submission_actions', 1, 3 );
+

--- a/includes/service/config.php
+++ b/includes/service/config.php
@@ -17,11 +17,12 @@ if ( ! function_exists( 'dekode_ninja_forms_uploads_azure_setting_wrapper' ) ) {
 	function dekode_ninja_forms_uploads_azure_setting_wrapper( array $config ): array {
 		$setting_name = $config['id'];
 
-		if ( ! isset( $config['desc'] ) ) {
-			$config['desc'] = '';
-		} else {
-			$config['desc'] .= '<br/>';
-		}
+		if ( $setting_name && defined( $setting_name ) ) {
+			if ( ! isset( $config['desc'] ) ) {
+				$config['desc'] = '';
+			} else {
+				$config['desc'] .= '<br/>';
+			}
 
 			$config['desc'] .= sprintf(
 				'<strong>%s</strong>',
@@ -34,7 +35,7 @@ if ( ! function_exists( 'dekode_ninja_forms_uploads_azure_setting_wrapper' ) ) {
 					esc_html( constant( $setting_name ) )
 				)
 			);
-
+		}
 		return $config;
 	}
 }

--- a/includes/service/config.php
+++ b/includes/service/config.php
@@ -17,25 +17,24 @@ if ( ! function_exists( 'dekode_ninja_forms_uploads_azure_setting_wrapper' ) ) {
 	function dekode_ninja_forms_uploads_azure_setting_wrapper( array $config ): array {
 		$setting_name = $config['id'];
 
-		if ( $setting_name && defined( $setting_name ) ) {
-			if ( ! isset( $config['desc'] ) ) {
-				$config['desc'] = '';
-			} else {
-				$config['desc'] .= '<br/>';
-			}
+		if ( ! isset( $config['desc'] ) ) {
+			$config['desc'] = '';
+		} else {
+			$config['desc'] .= '<br/>';
+		}
 
 			$config['desc'] .= sprintf(
 				'<strong>%s</strong>',
 				sprintf(
+					// translators: %s: constant name.
 					__(
-						// translators: %s: constant name.
 						'This value is defined in your websites wp-config.php file with the value `%s`. You may override that value by filling in the field above.',
 						'dekode-ninjaforms-azure'
 					),
 					esc_html( constant( $setting_name ) )
 				)
-           );
-		}
+			);
+
 		return $config;
 	}
 }


### PR DESCRIPTION
The changes request:

```
Ønsker at dere utvider pluginet til å autoaktivere, dvs at man slipper å;

Define connection setting (https://site.com/wp/wp-admin/admin.php?page=ninja-forms-uploads&tab=external)
Switch off 'SAVE TO SERVER' setting on File Upload field.
Add 'External File Upload' action to form and enable uploading to 'MICROSOFT AZURE'
```

Ticket: https://prosjekt.dekode.no/desk/tickets/6363547/messages